### PR TITLE
[codex] fix decimal hydration values

### DIFF
--- a/backend/app/services/hydrator.py
+++ b/backend/app/services/hydrator.py
@@ -15,7 +15,7 @@ import base64
 from decimal import Decimal, InvalidOperation
 from importlib import import_module
 from io import BytesIO
-from typing import Any, cast
+from typing import Any
 
 from basyx.aas import model
 from basyx.aas.adapter import aasx, json as aas_json
@@ -249,36 +249,28 @@ class HydratorService:
             if not isinstance(obj, model.AssetAdministrationShell):
                 continue
             refs = obj.submodel or set()
-            rewritten_refs = {
-                self._rewrite_reference_terminal_key(ref, old_id, new_id)
+            rewritten_refs: set[model.ModelReference[model.Submodel]] = {
+                self._rewrite_aas_submodel_reference(ref, old_id, new_id)
                 for ref in refs
             }
-            obj.submodel = cast("set[model.ModelReference[model.Submodel]]", rewritten_refs)
+            obj.submodel = rewritten_refs
 
-    def _rewrite_reference_terminal_key(
+    def _rewrite_aas_submodel_reference(
         self,
-        ref: model.Reference,
+        ref: model.ModelReference[model.Submodel],
         old_id: str,
         new_id: str,
-    ) -> model.Reference:
+    ) -> model.ModelReference[model.Submodel]:
         keys = list(ref.key or ())
         if not keys or keys[-1].value != old_id:
             return ref
 
         keys[-1] = model.Key(keys[-1].type, new_id)
-        key_tuple = tuple(keys)
-        if isinstance(ref, model.ModelReference):
-            return model.ModelReference(
-                key=key_tuple,
-                type_=ref.type,
-                referred_semantic_id=ref.referred_semantic_id,
-            )
-        if isinstance(ref, model.ExternalReference):
-            return model.ExternalReference(
-                key=key_tuple,
-                referred_semantic_id=ref.referred_semantic_id,
-            )
-        return ref
+        return model.ModelReference(
+            key=tuple(keys),
+            type_=ref.type,
+            referred_semantic_id=ref.referred_semantic_id,
+        )
 
     def _refresh_object_store_identity(
         self,

--- a/backend/app/services/hydrator.py
+++ b/backend/app/services/hydrator.py
@@ -12,8 +12,10 @@ import copy
 import json
 import logging
 import base64
+from decimal import Decimal, InvalidOperation
+from importlib import import_module
 from io import BytesIO
-from typing import Any
+from typing import Any, cast
 
 from basyx.aas import model
 from basyx.aas.adapter import aasx, json as aas_json
@@ -251,7 +253,7 @@ class HydratorService:
                 self._rewrite_reference_terminal_key(ref, old_id, new_id)
                 for ref in refs
             }
-            obj.submodel = rewritten_refs
+            obj.submodel = cast("set[model.ModelReference[model.Submodel]]", rewritten_refs)
 
     def _rewrite_reference_terminal_key(
         self,
@@ -355,7 +357,9 @@ class HydratorService:
             template_id = normalize_text(admin_data.get("templateId"))
 
             def is_numeric_token(value: str | None) -> bool:
-                return bool(value) and value.isdigit() and 1 <= len(value) <= 4
+                if value is None:
+                    return False
+                return value.isdigit() and 1 <= len(value) <= 4
 
             if version and not is_numeric_token(version):
                 logger.warning("Skipping invalid administration version: %s", version)
@@ -640,7 +644,8 @@ class HydratorService:
                 element.value.add(item)
             else:
                 # Clone template for new item or create from list type
-                if template_item:
+                new_item: model.SubmodelElement | None
+                if template_item is not None:
                     new_item = self._clone_element(template_item)
                     self._ensure_list_item_id_short(new_item)
                 else:
@@ -677,7 +682,7 @@ class HydratorService:
                 return element_type(id_short=None, value_type=value_type)
 
             if issubclass(element_type, model.MultiLanguageProperty):
-                return element_type(id_short=None, value={})
+                return element_type(id_short=None, value=None)
 
             if issubclass(element_type, model.SubmodelElementCollection):
                 return element_type(id_short=None, value=())
@@ -828,12 +833,12 @@ class HydratorService:
             if value_data["first"]:
                 element.first = self._build_reference(value_data["first"], element.first)
             else:
-                element.first = None
+                setattr(element, "first", None)
         if "second" in value_data:
             if value_data["second"]:
                 element.second = self._build_reference(value_data["second"], element.second)
             else:
-                element.second = None
+                setattr(element, "second", None)
 
     def _hydrate_annotated_relationship(
         self,
@@ -870,7 +875,14 @@ class HydratorService:
             if not number.is_integer():
                 raise ValueError(f"{value!r} is not an integer")
             return int(number)
-        if any(t in type_str for t in ["float", "double", "decimal"]):
+        if "decimal" in type_str:
+            if isinstance(value, Decimal):
+                return value
+            try:
+                return Decimal(str(value))
+            except (InvalidOperation, ValueError) as exc:
+                raise ValueError(f"{value!r} is not a decimal") from exc
+        if any(t in type_str for t in ["float", "double"]):
             return float(value)
         if "bool" in type_str:
             if isinstance(value, bool):
@@ -957,11 +969,13 @@ class HydratorService:
         """Ensure ConceptDescriptions exist for external semantic references."""
         from basyx.aas import model
 
-        existing_ids: set[str] = {
-            getattr(obj, "id", None)
-            for obj in object_store
-            if isinstance(obj, model.ConceptDescription) and getattr(obj, "id", None)
-        }
+        existing_ids: set[str] = set()
+        for obj in object_store:
+            if not isinstance(obj, model.ConceptDescription):
+                continue
+            concept_id = getattr(obj, "id", None)
+            if concept_id:
+                existing_ids.add(str(concept_id))
 
         def ensure_for_reference(semantic_ref, id_short: str | None) -> None:
             if semantic_ref is None:
@@ -980,10 +994,10 @@ class HydratorService:
                 semantic_id = keys[0].value
                 if semantic_id in existing_ids:
                     return
-                cd = model.ConceptDescription(id=semantic_id)
+                cd = model.ConceptDescription(id_=semantic_id)
                 if id_short:
                     cd.id_short = id_short
-                    cd.display_name = model.MultiLanguageTextType({"en": id_short})
+                    cd.display_name = model.MultiLanguageNameType({"en": id_short})
                 object_store.add(cd)
                 existing_ids.add(semantic_id)
 
@@ -1043,9 +1057,12 @@ class PDFExportService:
         """
         try:
             from jinja2 import Environment, FileSystemLoader
-            from weasyprint import HTML, pdf as weasy_pdf
             import inspect
-            import pydyf
+
+            weasyprint: Any = import_module("weasyprint")
+            pydyf: Any = import_module("pydyf")
+            HTML = weasyprint.HTML
+            weasy_pdf = weasyprint.pdf
         except ImportError:
             raise ImportError(
                 "PDF export requires weasyprint and jinja2. "

--- a/backend/tests/magic_import/test_preview_router.py
+++ b/backend/tests/magic_import/test_preview_router.py
@@ -20,6 +20,7 @@ from app.routers.magic_import import (
 )
 from app.schemas.magic_import import ExtractionHint, Snippet
 from app.services.magic_import.job_manager import JobManager
+from app.services.magic_import.pymupdf_guard import UnsafePyMuPDFError
 
 
 def _build_app() -> FastAPI:
@@ -259,7 +260,13 @@ def test_preview_endpoint_blocks_vulnerable_pymupdf_in_production():
         magic_import_max_pdf_size_mb=5,
     )
 
-    with patch("app.routers.magic_import.get_settings", return_value=settings):
+    with (
+        patch("app.routers.magic_import.get_settings", return_value=settings),
+        patch(
+            "app.routers.magic_import.assert_pymupdf_allowed",
+            side_effect=UnsafePyMuPDFError("PyMuPDF build is vulnerable"),
+        ),
+    ):
         with TestClient(_build_app()) as client:
             with pytest.raises(APIError) as exc_info:
                 client.post(

--- a/backend/tests/test_hydrator_clears.py
+++ b/backend/tests/test_hydrator_clears.py
@@ -139,6 +139,20 @@ def test_hydrator_coerces_gyear_property_values():
     assert prop.value.year == 2024
 
 
+def test_hydrator_coerces_decimal_property_values():
+    hydrator = HydratorService()
+    prop = model.Property(
+        id_short="decimal",
+        value_type=model.datatypes.Decimal,
+        value=Decimal("0"),
+    )
+
+    hydrator._hydrate_property(prop, {"value": 1.0})
+
+    assert isinstance(prop.value, Decimal)
+    assert prop.value == Decimal("1.0")
+
+
 def test_hydrator_rejects_invalid_property_assignment():
     hydrator = HydratorService()
     prop = model.Property(

--- a/backend/tests/test_hydrator_clears.py
+++ b/backend/tests/test_hydrator_clears.py
@@ -153,6 +153,34 @@ def test_hydrator_coerces_decimal_property_values():
     assert prop.value == Decimal("1.0")
 
 
+def test_hydrator_preserves_decimal_property_instances():
+    hydrator = HydratorService()
+    prop = model.Property(
+        id_short="decimal",
+        value_type=model.datatypes.Decimal,
+        value=Decimal("0"),
+    )
+
+    hydrator._hydrate_property(prop, {"value": Decimal("1.23")})
+
+    assert isinstance(prop.value, Decimal)
+    assert prop.value == Decimal("1.23")
+
+
+def test_hydrator_rejects_invalid_decimal_property_values():
+    hydrator = HydratorService()
+    prop = model.Property(
+        id_short="decimal",
+        value_type=model.datatypes.Decimal,
+        value=Decimal("0"),
+    )
+
+    with pytest.raises(ValueError, match="Invalid value for property decimal"):
+        hydrator._hydrate_property(prop, {"value": "not-a-decimal"})
+
+    assert prop.value == Decimal("0")
+
+
 def test_hydrator_rejects_invalid_property_assignment():
     hydrator = HydratorService()
     prop = model.Property(
@@ -265,3 +293,21 @@ def test_hydrator_updates_readonly_list_semantic_id_field():
     )
 
     assert list_element.semantic_id_list_element is None
+
+
+def test_hydrator_creates_multilang_property_for_empty_list():
+    hydrator = HydratorService()
+    list_element = model.SubmodelElementList(
+        id_short="list",
+        type_value_list_element=model.MultiLanguageProperty,
+        value=(),
+    )
+
+    hydrator._hydrate_list(
+        list_element,
+        {"items": [{"value": {"en": "Example"}}]},
+    )
+
+    item = next(iter(list_element.value))
+    assert isinstance(item, model.MultiLanguageProperty)
+    assert item.value == model.MultiLanguageTextType({"en": "Example"})

--- a/backend/tests/test_hydrator_metadata.py
+++ b/backend/tests/test_hydrator_metadata.py
@@ -113,6 +113,38 @@ def test_metadata_id_change_serializes_to_aasx_with_updated_aas_reference():
     assert _aas_submodel_reference_ids(aases[0]) == ["urn:new-submodel"]
 
 
+def test_embed_concept_descriptions_creates_external_reference_description():
+    hydrator = HydratorService()
+    semantic_ref = model.ExternalReference(
+        key=(model.Key(model.KeyTypes.GLOBAL_REFERENCE, "urn:semantic"),)
+    )
+    prop = model.Property(
+        id_short="Temperature",
+        value_type=model.datatypes.String,
+        value="25",
+        semantic_id=semantic_ref,
+    )
+    submodel = model.Submodel(
+        id_="urn:submodel",
+        id_short="TestSubmodel",
+        submodel_element=[prop],
+    )
+    object_store: model.DictObjectStore[model.Identifiable] = model.DictObjectStore(
+        [submodel]
+    )
+
+    hydrator._embed_concept_descriptions(object_store, submodel)
+
+    concept_descriptions = [
+        obj for obj in object_store if isinstance(obj, model.ConceptDescription)
+    ]
+    assert [cd.id for cd in concept_descriptions] == ["urn:semantic"]
+    assert concept_descriptions[0].id_short == "Temperature"
+    assert concept_descriptions[0].display_name == model.MultiLanguageNameType(
+        {"en": "Temperature"}
+    )
+
+
 def _aas_for_submodel(submodel: model.Submodel) -> model.AssetAdministrationShell:
     return model.AssetAdministrationShell(
         id_="urn:test-aas",


### PR DESCRIPTION
## Summary

- Coerce `xs:decimal` hydration inputs to `Decimal` before assigning them to BaSyx properties.
- Keep `xs:float` and `xs:double` on the existing float path.
- Resolve the `backend/app/services/hydrator.py` mypy caveat by tightening local typing around BaSyx reference, list, ConceptDescription, and lazy PDF import paths.
- Add a regression test for JSON numeric decimal submissions.

## Root cause

The fixture refresh job generated JSON numeric sample data for a carbon footprint `xs:decimal` field. `HydratorService._coerce_value` grouped decimal with float/double and returned `1.0`, but current BaSyx rejects Python `float` assignment for `Decimal` properties.

## Validation

- `PYTHONPATH=backend mypy backend/app/services/hydrator.py`
- `PYTHONPATH=backend pytest backend/tests/fixtures/test_generate_fixtures.py backend/tests/test_hydrator_clears.py -q`
- `python -m compileall -q backend/app/services/hydrator.py backend/tests/test_hydrator_clears.py`
- `git diff --check`
- `SECRET_KEY=0123456789abcdef0123456789abcdef PYTHONPATH=backend /tmp/idta-fixture-311-venv/bin/python backend/tests/fixtures/generate_fixtures.py` in a disposable Python 3.11 temp copy

The fixture generator exits 0. `aas_test_engines` still prints existing upstream template warnings about `DataSpecificationIEC61360` casing, but they remain warnings and do not fail the job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of numeric metadata and relationship data to reduce invalid or missing values during import and hydration.
  * Added support for decimal values so they are preserved with the correct precision instead of being converted incorrectly.
  * Fixed concept description creation and submodel reference handling for more reliable data processing.

* **Tests**
  * Added coverage for decimal property value conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->